### PR TITLE
Deploy to an existing vpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ export MASTER_SIZE='t2.medium'
 export DATADOG_API_KEY=''
 
 export USE_BASTION="true" # true or false
+
+# used for deploying to an existing vpc
+export VPC_ID=''
+export NETWORK_CIDR=''
 ```
 
 3. Run ./kube-setup/setup-cluster

--- a/kube-setup/manage-cluster/create
+++ b/kube-setup/manage-cluster/create
@@ -67,11 +67,26 @@ createCommand="kops create cluster \
     --ssh-public-key $SSH_PUBLIC_KEY_FILE \
     --bastion=\"${USE_BASTION}\" "
 
+if [ ! -e $VPC_ID ] && [ ! -e $NETWORK_CIDR ]; then
+  createCommand="$createCommand \
+    --vpc $VPC_ID \
+    --network-cidr $NETWORK_CIDR"
+fi
+
 confirmClusterCommand="kops update cluster ${KUBE_CLUSTER_NAME} --yes"
 
 # create cluster for real
 eval $createCommand
 echo -e "\n\n"
+
+read -r -d '' editSpecQuestionText <<-EOF
+  Would you like to edit the cluster's spec before launching?
+EOF
+
+askYesNoQuestion "${editSpecQuestionText}"
+if [ $? -eq 1 ]; then
+  kops edit cluster $KUBE_CLUSTER_NAME
+fi
 
 read -r -d '' questionText <<-EOF
 !!! WARNING !!!


### PR DESCRIPTION
In order to deploy a new cluster to an existing vpc, we can use the `vpc` and `network-cidr` flags that [`kops create cluster`](https://github.com/kubernetes/kops/blob/master/docs/cli/kops_create_cluster.md) allows us to specify.

A full description of how to do this can be found here:
https://stackoverflow.com/c/dtstarts/questions/22/25