### PR TITLE
Expire after a year

### DIFF
--- a/kube-setup/manage-cluster/user/add
+++ b/kube-setup/manage-cluster/user/add
@@ -45,7 +45,7 @@ openssl x509 -req \
   -CAserial "${outputDir}${USER_SRL_FILE}" \
   -CAcreateserial \
   -out "${userOutputDir}${USER_CRT_FILE}"
-# -days 365
+  -days 365
 
 bindingName="${USERNAME}-cluster-admin-binding"
 


### PR DESCRIPTION
By default, OpenSSL expires certs after 30 days. The `add` script in the `/users` directory had the days flag commented out. This is why my K8s users "randomly" couldn't access the cluster. Adjusting this so it's less of a pain in the ass.